### PR TITLE
Add init app method for custom app config

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -18,6 +18,18 @@ To begin, import xpublish and open an xarray dataset:
         "air_temperature", chunks=dict(lat=5, lon=5),
     )
 
+Optional customization of the underlying FastAPI application is available by using the ``init_app`` method before running ``serve`` below:
+
+.. ipython:: python
+
+    ds.rest.init_app(
+        title="My Dataset",
+        description="Dataset Description",
+        version="1.0.0",
+        openapi_url="/dataset.json",
+        docs_url="/data-docs"
+    )
+
 Serving a dataset simply requires calling the `serve` method on the `rest`
 accessor:
 
@@ -48,7 +60,7 @@ Zarr API
 API Docs
 ~~~~~~~~
 
-* ``/docs``: Interactive Swagger UI API documentation
+* ``/docs``: Interactive Swagger UI API documentation. This can be set with ``docs_url`` parameter when initializing application.
 
 Client-Side
 -----------

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -15,8 +15,27 @@ def airtemp_ds():
 
 @pytest.fixture(scope="module")
 def airtemp_app(airtemp_ds):
+    airtemp_ds.rest.init_app(
+        title="My Dataset",
+        description="Dataset Description",
+        version="1.0.0",
+        openapi_url="/dataset.json",
+        docs_url="/data-docs",
+    )
     client = TestClient(airtemp_ds.rest.app)
     yield client
+
+
+def test_init_app(airtemp_ds, airtemp_app):
+    assert airtemp_ds.rest.app.title == "My Dataset"
+    assert airtemp_ds.rest.app.description == "Dataset Description"
+    assert airtemp_ds.rest.app.version == "1.0.0"
+
+    response = airtemp_app.get('/dataset.json')
+    assert response.status_code == 200
+
+    response = airtemp_app.get('/data-docs')
+    assert response.status_code == 200
 
 
 def test_keys(airtemp_ds, airtemp_app):

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -104,9 +104,48 @@ class RestAccessor:
         )
         return Response(echunk, media_type="application/octet-stream")
 
-    def init_app(self, **kwargs):
+    def init_app(self,
+                 debug=False,
+                 title='FastAPI',
+                 description='',
+                 version='0.1.0',
+                 openapi_url='/openapi.json',
+                 docs_url='/docs',
+                 openapi_prefix='',
+                 **kwargs):
+        """ Initiate FastAPI Application.
 
-        self._app = FastAPI(**kwargs)
+        Parameters
+        ----------
+        debug : bool
+            Boolean indicating if debug tracebacks for
+            FastAPI application should be returned on errors.
+        title : str
+            API's title/name, in OpenAPI and the automatic API docs UIs.
+        description : str
+            API's description text, in OpenAPI and the automatic API docs UIs.
+        version : str
+            API's, e.g. v2 or 2.5.0.
+        openapi_url: str
+            Set OpenAPI schema json url. Default at /openapi.json.
+        docs_url : str
+            Set Swagger UI API documentation URL. Set to ``None`` to disable.
+        openapi_prefix : str
+            Set root url of where application will be hosted.
+        kwargs :
+            Additional arguments to be passed to ``FastAPI``.
+            See https://tinyurl.com/fastapi for complete list.
+        """
+
+        self._app = FastAPI(
+            debug=debug,
+            title=title,
+            description=description,
+            version=version,
+            openapi_url=openapi_url,
+            docs_url=docs_url,
+            openapi_prefix=openapi_prefix,
+            **kwargs)
 
         @self._app.get(f"/{zarr_metadata_key}")
         def get_zmetadata():

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -86,7 +86,9 @@ class RestAccessor:
             compressor_config = zjson["metadata"][f"{key}/{array_meta_key}"][
                 "compressor"
             ].get_config()
-            zjson["metadata"][f"{key}/{array_meta_key}"]["compressor"] = compressor_config
+            zjson["metadata"][f"{key}/{array_meta_key}"][
+                "compressor"
+            ] = compressor_config
 
         return zjson
 
@@ -100,14 +102,16 @@ class RestAccessor:
         data_chunk = get_data_chunk(da, chunk, out_shape=arr_meta["chunks"])
 
         echunk = _encode_chunk(
-            data_chunk.tobytes(), filters=arr_meta["filters"], compressor=arr_meta["compressor"],
+            data_chunk.tobytes(),
+            filters=arr_meta["filters"],
+            compressor=arr_meta["compressor"],
         )
         return Response(echunk, media_type="application/octet-stream")
 
     def init_app(self, **kwargs):
-        
+
         self._app = FastAPI(**kwargs)
-        
+
         @self._app.get(f"/{zarr_metadata_key}")
         def get_zmetadata():
             return self.zmetadata_json()
@@ -147,6 +151,7 @@ class RestAccessor:
                 xr.show_versions(f)
                 versions = f.getvalue()
             return versions
+
         return self._app
 
     @property
@@ -203,7 +208,9 @@ def _extract_fill_value(da, dtype):
 def extract_zarray(da, encoding, dtype):
     """ helper function to extract zarr array metadata. """
     meta = {
-        "compressor": encoding.get("compressor", da.encoding.get("compressor", default_compressor)),
+        "compressor": encoding.get(
+            "compressor", da.encoding.get("compressor", default_compressor)
+        ),
         "filters": encoding.get("filters", da.encoding.get("filters", None)),
         "chunks": encoding.get("chunks", None),
         "dtype": dtype.str,

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -86,9 +86,7 @@ class RestAccessor:
             compressor_config = zjson["metadata"][f"{key}/{array_meta_key}"][
                 "compressor"
             ].get_config()
-            zjson["metadata"][f"{key}/{array_meta_key}"][
-                "compressor"
-            ] = compressor_config
+            zjson["metadata"][f"{key}/{array_meta_key}"]["compressor"] = compressor_config
 
         return zjson
 
@@ -102,9 +100,7 @@ class RestAccessor:
         data_chunk = get_data_chunk(da, chunk, out_shape=arr_meta["chunks"])
 
         echunk = _encode_chunk(
-            data_chunk.tobytes(),
-            filters=arr_meta["filters"],
-            compressor=arr_meta["compressor"],
+            data_chunk.tobytes(), filters=arr_meta["filters"], compressor=arr_meta["compressor"],
         )
         return Response(echunk, media_type="application/octet-stream")
 
@@ -206,9 +202,7 @@ def _extract_fill_value(da, dtype):
 def extract_zarray(da, encoding, dtype):
     """ helper function to extract zarr array metadata. """
     meta = {
-        "compressor": encoding.get(
-            "compressor", da.encoding.get("compressor", default_compressor)
-        ),
+        "compressor": encoding.get("compressor", da.encoding.get("compressor", default_compressor)),
         "filters": encoding.get("filters", da.encoding.get("filters", None)),
         "chunks": encoding.get("chunks", None),
         "dtype": dtype.str,

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -127,7 +127,7 @@ class RestAccessor:
         description : str
             API's description text, in OpenAPI and the automatic API docs UIs.
         version : str
-            API's, e.g. v2 or 2.5.0.
+            API's version, e.g. v2 or 2.5.0.
         openapi_url: str
             Set OpenAPI schema json url. Default at /openapi.json.
         docs_url : str

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -180,8 +180,6 @@ class RestAccessor:
         -----
         This method is blocking and does not return.
         """
-        if self._app is None:
-            self.init_app()
         uvicorn.run(self.app, host=host, port=port, log_level=log_level, **kwargs)
 
 

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -104,15 +104,17 @@ class RestAccessor:
         )
         return Response(echunk, media_type="application/octet-stream")
 
-    def init_app(self,
-                 debug=False,
-                 title='FastAPI',
-                 description='',
-                 version='0.1.0',
-                 openapi_url='/openapi.json',
-                 docs_url='/docs',
-                 openapi_prefix='',
-                 **kwargs):
+    def init_app(
+        self,
+        debug=False,
+        title='FastAPI',
+        description='',
+        version='0.1.0',
+        openapi_url='/openapi.json',
+        docs_url='/docs',
+        openapi_prefix='',
+        **kwargs,
+    ):
         """ Initiate FastAPI Application.
 
         Parameters
@@ -145,7 +147,8 @@ class RestAccessor:
             openapi_url=openapi_url,
             docs_url=docs_url,
             openapi_prefix=openapi_prefix,
-            **kwargs)
+            **kwargs,
+        )
 
         @self._app.get(f"/{zarr_metadata_key}")
         def get_zmetadata():


### PR DESCRIPTION
## Overview

Adding `init_app` method to set additional configuration to `FastAPI` configuration to allow more control to app and expand.

Need this for sub-application to build proxying for multiple datasets: https://fastapi.tiangolo.com/advanced/sub-applications-proxy/