### PR TITLE
Fix unicode decode error

### DIFF
--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -1,5 +1,6 @@
 import copy
 import importlib
+import json
 import logging
 import sys
 
@@ -91,7 +92,7 @@ class RestAccessor:
             ].get_config()
             zjson["metadata"][f"{key}/{array_meta_key}"]["compressor"] = compressor_config
 
-        return zjson
+        return Response(json.dumps(zjson).encode('ascii'), media_type="application/json")
 
     async def get_key(self, var, chunk):
         logger.debug("var is %s", var)

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -92,7 +92,7 @@ class RestAccessor:
             ].get_config()
             zjson["metadata"][f"{key}/{array_meta_key}"]["compressor"] = compressor_config
 
-        return Response(json.dumps(zjson).encode('ascii'), media_type="application/json")
+        return zjson
 
     async def get_key(self, var, chunk):
         logger.debug("var is %s", var)
@@ -194,7 +194,9 @@ class RestAccessor:
 
         @self._app.get(f"/{zarr_metadata_key}")
         def get_zmetadata():
-            return self.zmetadata_json()
+            return Response(
+                json.dumps(self.zmetadata_json()).encode('ascii'), media_type="application/json"
+            )
 
         @self._app.get("/keys")
         def list_keys():


### PR DESCRIPTION
## Overview

This fixes problem with encoding for JSON Response of the zmetadata.

## Problem

I ran into `UnicodeDecodeError` when trying to read one of my dataset that has been published.
```python
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 10229: ordinal not in range(128)
```

Based on the error it seems that the zarr library uses 'ascii' decoder to decode the json zmetadata. However, xpublish currently uses 'utf-8' encoding.

```python
/opt/conda/envs/xpub/lib/python3.6/site-packages/zarr/util.py in json_loads(s)
     28 def json_loads(s):
     29     """Read JSON in a consistent way."""
---> 30     return json.loads(ensure_text(s, 'ascii'))
     31 
     32 
```

## Conclusion

The solution in this PR ensures that the zmetadata json is encoded with 'ascii' rather than 'utf-8'.