### PR TITLE
Fix async clash with dask

### DIFF
--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -93,7 +93,7 @@ class RestAccessor:
 
         return zjson
 
-    async def get_key(self, var, chunk):
+    def get_key(self, var, chunk):
         logger.debug("var is %s", var)
         logger.debug("chunk is %s", chunk)
 
@@ -213,8 +213,8 @@ class RestAccessor:
             return self._obj.to_dict(data=data)
 
         @self._app.get("/{var}/{chunk}")
-        async def get_key(var, chunk):
-            result = await self.get_key(var, chunk)
+        def get_key(var, chunk):
+            result = self.get_key(var, chunk)
             return result
 
         @self._app.get("/versions")


### PR DESCRIPTION
## Overview

This PR fixes #7.

## Problem

It appears that there was a clash/confusion between the uvicorn event loop and the dask distributed event loop. When using `async` in a FastAPI app, this method will be sent to the uvicorn event loop. So the request for individual chunks were processed concurrently. Each dask compute becomes blocking and is only processed by one worker which I think is part of the uvicron event loop.

## Solution

To allow dask to actually compute in parallel the async and await for `get_key` should be remove, which frees up this method to use the compute within dask distributed event loop rather than the uvicorn event loop.