### PR TITLE
Add API endpoints for data variable and coordinate keys

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -51,6 +51,8 @@ REST API
 
 * ``/``: returns xarray's HTML repr.
 * ``/keys``: returns a list of variable keys, equivalent to ``list(ds.variables)``.
+* ``/data_var_keys``: returns a list of data variable keys, equivalent to ``list(ds.data_vars)``.
+* ``/coord_keys``: returns a list of coordinate keys, equivalent to ``list(ds.coords)``.
 * ``/info``: returns a JSON dictionary summary of a Dataset variables and attributes, similar to ``ds.info()``.
 * ``/dict``: returns a JSON dictionary of the full dataset.
 * ``/versions``: returns JSON dictionary of the versions of python, xarray and related libraries on the server side, similar to ``xr.show_versions()``.

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -51,10 +51,15 @@ def test_init_app(airtemp_ds):
     assert response.status_code == 200
 
 
-def test_keys(airtemp_ds, airtemp_app):
-    response = airtemp_app.get('/keys')
+@pytest.mark.parametrize('endpoint,obj_attr', [
+    ('/keys', 'variables'),
+    ('/data_var_keys', 'data_vars'),
+    ('/coord_keys', 'coords')
+])
+def test_keys(airtemp_ds, airtemp_app, endpoint, obj_attr):
+    response = airtemp_app.get(endpoint)
     assert response.status_code == 200
-    assert response.json() == list(airtemp_ds.variables)
+    assert response.json() == list(getattr(airtemp_ds, obj_attr))
 
 
 def test_info(airtemp_ds, airtemp_app):

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -240,6 +240,14 @@ class RestAccessor:
         def list_keys():
             return list(self._obj.variables)
 
+        @self._app.get('/data_var_keys')
+        def list_data_var_keys():
+            return list(self._obj.data_vars.keys())
+
+        @self._app.get('/coord_keys')
+        def list_coord_keys():
+            return list(self._obj.coords.keys())
+
         @self._app.get('/')
         def repr():
             with xr.set_options(display_style='html'):


### PR DESCRIPTION
This may be useful, in addition to `/keys`. 

I picked `/data_var_keys` and `/coord_keys` as endpoints, but I don't have strong opinion on this.